### PR TITLE
"nave use stable" fails (node 0.6.0 is stable but directory for 0.6.1 exists on server)

### DIFF
--- a/nave.sh
+++ b/nave.sh
@@ -229,7 +229,7 @@ nave_latest () {
     | tail -n1
 }
 nave_stable () {
-  curl -s http://nodejs.org/dist/ \
+  curl -s http://nodejs.org/dist/latest/ \
     | egrep -o '[0-9]+\.[2468]\.[0-9]+' \
     | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
     | tail -n1


### PR DESCRIPTION
I've made a big assumption here that the node in /dist/latest/ will be the stable release, obviously if that's wrong feel free to dump this!
