### PR TITLE
Make JOBS default to 2 for all installs, not just usemain

### DIFF
--- a/nave.sh
+++ b/nave.sh
@@ -142,6 +142,20 @@ nave_fetch () {
   return 0
 }
 
+build () {
+  local version="$1"
+  nave_fetch "$version"
+  local src="$NAVE_SRC/$version"
+
+  ( cd -- "$src"
+    JOBS=${JOBS:-2} ./configure --debug --prefix="$2" \
+      || fail "Failed to configure $version"
+    JOBS=${JOBS:-2} make \
+      || fail "Failed to make $version"
+    make install || fail "Failed to install $version"
+  ) || fail "fail"
+}
+
 nave_usemain () {
   if [ ${NAVELVL-0} -gt 0 ]; then
     fail "Can't usemain inside a nave subshell. Exit to main shell."
@@ -161,16 +175,8 @@ nave_usemain () {
     echo "$version already installed"
     return 0
   fi
-  nave_fetch "$version"
-  src="$NAVE_SRC/$version"
 
-  ( cd -- "$src"
-    JOBS=${JOBS:-2} ./configure --debug --prefix $prefix \
-      || fail "Failed to configure $version"
-    JOBS=${JOBS:-2} make \
-      || fail "Failed to make $version in main env"
-    make install || fail "Failed to install $version in main env"
-  ) || fail "fail"
+  build "$version in main env" "$prefix"
 }
 
 nave_install () {
@@ -179,19 +185,11 @@ nave_install () {
     echo "Already installed: $version" >&2
     return 0
   fi
-  nave_fetch "$version"
-
-  local src="$NAVE_SRC/$version"
   local install="$NAVE_ROOT/$version"
   remove_dir "$install"
   ensure_dir "$install"
-  ( cd -- "$src"
-    JOBS=${JOBS:-2} ./configure --debug --prefix="$install" \
-      || fail "Failed to configure $version"
-    JOBS=${JOBS:-2} make \
-      || fail "Failed to make $version"
-    make install || fail "Failed to install $version"
-  ) || fail "fail"
+
+  build "$version" "$install"
 }
 
 nave_test () {


### PR DESCRIPTION
These 2 functions are very similar, perhaps it would be better if the code could be re-used somehow?
