### PR TITLE
as many jobs as CPU's

### DIFF
--- a/nave.sh
+++ b/nave.sh
@@ -186,7 +186,7 @@ build () {
     fi
     JOBS=${JOBS:-2} ./configure "${NAVE_CONFIG[@]}" --prefix="$2" \
       || fail "Failed to configure $version"
-    JOBS=${JOBS:-2} make \
+    JOBS=${JOBS:-2} make -j$(sysctl -n hw.ncpu)\
       || fail "Failed to make $version"
     make install || fail "Failed to install $version"
   ) || fail "fail"


### PR DESCRIPTION
if sysctl does not have a value for hw.ncpu it should return null, which is a valid value for -j

And if sysctl does not exist then the value should evaluate to null and something would pop out on stderr, but again -j should be happy.

I do not have a plethora of OS's to test on, so I only tested on lion.  But... I did run the following:

$(sysctl -n hw.ncpu)
$(sysctl -n doesNotExist)
$(doesNotExist -n hw.ncpu)

And each one worked for me...
