### PR TITLE
Add alternate installation method to curl the nave.sh file and run it

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ equivalent to your init script:
 
     export PATH=$NAVE_PATH:$PATH
 
+## Alternate Installation
+
+You can also add this to your `~/.bashrc` or wherever you keep your
+aliases to always use the latest copy from github:
+
+```
+nave() { sudo sh -c "$(curl -s 'https://raw.github.com/isaacs/nave/master/nave.sh') $*"; }
+```
+
 ## Configuration
 
 Nave will source `~/.naverc` on initialization of a new subshell, if it


### PR DESCRIPTION
Just a quick shell function to make nave available by curling it whenever the user needs it
