### PR TITLE
Recognise all even minor versions as stable

### DIFF
--- a/nave.sh
+++ b/nave.sh
@@ -376,7 +376,7 @@ nave_latest () {
 
 nave_stable () {
   curl -s http://nodejs.org/dist/ \
-    | egrep -o '[0-9]+\.[1-9]?[02468]+\.[0-9]+' \
+    | egrep -o '[0-9]+\.([1-9][0-9]*)?[02468]\.[0-9]+' \
     | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
     | tail -n1
 }


### PR DESCRIPTION
The old pattern for determining stable versions only matches if the 2nd part is exactly two, four, six or eight. Change it to be ready for a possible 1.0 or 0.10 stable version in the future.
