### PR TITLE
`nave clean` more thoroughly

### DIFF
--- a/nave.sh
+++ b/nave.sh
@@ -577,7 +577,7 @@ add_named_env () {
 }
 
 nave_clean () {
-  rm -rf "$NAVE_SRC/$(ver "$1")" "$NAVE_SRC/$(ver "$1")".tgz
+  rm -rf "$NAVE_SRC/$(ver "$1")" "$NAVE_SRC/$(ver "$1")".tgz "$NAVE_SRC/$(ver "$1")"-*.tgz
 }
 
 nave_uninstall () {


### PR DESCRIPTION
Packaging node binaries per platform slightly broke clean-up.

"*-linux-x86.tgz" files were left in my src dir after `nave clean`.
