### PR TITLE
added checking pattern of arch for binary fetching

### DIFF
--- a/nave.sh
+++ b/nave.sh
@@ -46,13 +46,14 @@ shopt -s extglob
 # Try to figure out the os and arch for binary fetching
 uname="$(uname -a)"
 os=
-arch=x86
+arch=
 case "$uname" in
   Linux\ *) os=linux ;;
   Darwin\ *) os=darwin ;;
   SunOS\ *) os=sunos ;;
 esac
 case "$uname" in
+  *i386*) arch=x86 ;;
   *x86_64*) arch=x64 ;;
 esac
 


### PR DESCRIPTION
nave installs binary package for non intel-based linux. I fixed that set empty to "arch" when Linux is running on except intel processors.