### PR TITLE
Check for the mandatory `version` parameter in `nave install`

### DIFF
--- a/nave.sh
+++ b/nave.sh
@@ -321,6 +321,9 @@ nave_usemain () {
 
 nave_install () {
   local version=$(ver "$1")
+  if [ -z "$version" ]; then
+    fail "Must supply a version ('stable', 'latest' or numeric)"
+  fi
   if nave_installed "$version"; then
     echo "Already installed: $version" >&2
     return 0


### PR DESCRIPTION
I tried to launch `nave install` without specifing a version since I was not sure which version I wanted, and it failed in a weird way. Looking at the code it turned out that the `version` parameter is not optional, so I added an explicit check for it.
