### PR TITLE
Link to npm in named env (fixes isaacs/nave#49)

### DIFF
--- a/nave.sh
+++ b/nave.sh
@@ -644,6 +644,7 @@ add_named_env () {
   ensure_dir "$NAVE_ROOT/$name/share/man"
 
   ln -sf -- "$NAVE_ROOT/$version/bin/node" "$NAVE_ROOT/$name/bin/node"
+  ln -sf -- "$NAVE_ROOT/$version/bin/npm"  "$NAVE_ROOT/$name/bin/npm"
   ln -sf -- "$NAVE_ROOT/$version/bin/node-waf" "$NAVE_ROOT/$name/bin/node-waf"
 }
 


### PR DESCRIPTION
Add link to npm when creating a named environment