### PR TITLE
Fix x86 arch calculation

### DIFF
--- a/nave.sh
+++ b/nave.sh
@@ -53,7 +53,7 @@ case "$uname" in
   SunOS\ *) os=sunos ;;
 esac
 case "$uname" in
-  *i386*) arch=x86 ;;
+  *i[3456]86*) arch=x86 ;;
   *x86_64*) arch=x64 ;;
   *raspberrypi*) arch=arm-pi ;;
 esac


### PR DESCRIPTION
- After commit 29a7c04f25d3a7c443902602a273fd4825cb0a7a nave stopped working
  correctly for x86 kernels different from i386.
