### PR TITLE
fixed 'node: command not found' error...

### DIFF
--- a/nave.sh
+++ b/nave.sh
@@ -311,7 +311,7 @@ nave_usemain () {
     fail "Can't usemain inside a nave subshell. Exit to main shell."
   fi
   local version=$(ver "$1")
-  local current=$(node -v || true)
+  local current=$(command -v node >/dev/null 2>&1 && node -v)
   local wn=$(which node || true)
   local prefix="/usr/local"
   if [ "x$wn" != "x" ]; then


### PR DESCRIPTION
...in usemain on systems without any previous node install.

to reproduce the bug in the current version run:
```
$ sudo mv /usr/local/bin/node /usr/local/bin/node.bkp
$ nave usemain v1.6.3
nave line 315: node: command not found
$ sudo mv /usr/local/bin/node.bkp /usr/local/bin/node
```