### PR TITLE
Fix binavail calculation for versions prior to 0.8.0

### DIFF
--- a/nave.sh
+++ b/nave.sh
@@ -251,7 +251,7 @@ build () {
     # binaries started with node 0.8.6
     case "$version" in
       0.8.[012345]) binavail=0 ;;
-      0.[1234567]) binavail=0 ;;
+      0.[1234567].*) binavail=0 ;;
       *) binavail=1 ;;
     esac
     if [ $binavail -eq 1 ]; then


### PR DESCRIPTION
`0.[1234567]` does not match `0.5.4`, which causes `binavail` to be set to `1`, rather than `0`.
Versions are never `X.X` – they are always `X.X.X`, even if that means being `X.X.0`.
`0.[1234567]*` is not used, as this would cause `binavail` to be set to `0` for `0.12.0`.