### PR TITLE
only set NAVE_DIR if undefined or empty

### DIFF
--- a/nave.sh
+++ b/nave.sh
@@ -81,7 +81,7 @@ main () {
               )/$(basename -- "$SYM")
   done
 
-  if ! [ -z "${NAVE_DIR+defined}" ]; then
+  if ! [ "$NAVE_DIR" ]; then
     if [ -d "$HOME" ]; then
       NAVE_DIR="$HOME"/.nave
     else


### PR DESCRIPTION
fix #81

eg
`NAVE_DIR=foo nave install 4.1.1` will install to foo
`NAVE_DIR="" nave install 4.1.1` will install to `$HOME/.nave`

otherwise will install to `$HOME/.nave`