### PR TITLE
Fix false check of NAVE_DIR environment variable

### DIFF
--- a/nave.sh
+++ b/nave.sh
@@ -81,7 +81,7 @@ main () {
               )/$(basename -- "$SYM")
   done
 
-  if ! [ -z "${NAVE_DIR+defined}" ]; then
+  if [ -z "${NAVE_DIR+defined}" ]; then
     if [ -d "$HOME" ]; then
       NAVE_DIR="$HOME"/.nave
     else


### PR DESCRIPTION
Bash's `test -z str` expression returns True when the length of _str_ is 0, otherwise False.
The variable check syntax like ${FOOBAR**+hahaha**} returns `hahaha` when the variable before **+** syntax is already defined, if not, returns 0-length string.

So, the missing expression before I fixed, see below, returns True when a NAVE_DIR environment variable is defined, because `${NAVE_DIR+defined}` syntax returns `defined` and, so `[ -z "${NAVE_DIR+defined}" ]`, will be equal to `[ -z "defined" ]`, returns False, and the negative expression **!** inverts the result.
 
```
 if ! [ -z "${NAVE_DIR+defined}" ]; then
```

Check this code, please. :)