### PR TITLE
Fix: arch detection on darwin

### DIFF
--- a/nave.sh
+++ b/nave.sh
@@ -58,8 +58,8 @@ case "$uname" in
   SunOS\ *) os=sunos ;;
 esac
 case "$uname" in
-  *i[3456]86*) arch=x86 ;;
   *x86_64*) arch=x64 ;;
+  *i[3456]86*) arch=x86 ;;
   *raspberrypi*) arch=arm-pi ;;
 esac
 


### PR DESCRIPTION
I'm not sure what changed/if this is just my machine, but for me:

```sh
uname -a
Darwin xxxxx 16.4.0 Darwin Kernel Version 16.4.0: Thu Dec 22 22:53:21 PST 2016; root:xnu-3789.41.3~3/RELEASE_X86_64 x86_64 i386 MacBookPro11,3 Darwin
```

Which means this case statement would set `$arch` to `x86`, which isn't valid for macOS downloads which are `x64`. This results in a 404 error, and nave fails to install anything. Switching the order produces the correct results for me. But I haven't tested on other architectures, so I'm not sure what the implications here.