### PR TITLE
Avoid double slashes in urls

### DIFF
--- a/nave.sh
+++ b/nave.sh
@@ -210,7 +210,7 @@ nave_fetch () {
   remove_dir "$src"
   ensure_dir "$src"
 
-  get "/v$version/node-v$version.tar.gz" -#Lf > "$src".tgz
+  get "v$version/node-v$version.tar.gz" -#Lf > "$src".tgz
   if [ $? -eq 0 ]; then
     $tar xzf "$src".tgz -C "$src" --strip-components=1
     if [ $? -eq 0 ]; then
@@ -336,7 +336,7 @@ build () {
     esac
     if [ $binavail -eq 1 ]; then
       local t="$version-$os-$arch"
-      local url="/v$version/node-v${t}.tar.gz"
+      local url="v$version/node-v${t}.tar.gz"
       get "$url" -#Lf | \
         $tar xz -C "$targetfolder" --strip-components 1
       if [ $? -ne 0 ]; then
@@ -585,7 +585,7 @@ nave_lts () {
   esac
   # echo "nave_lts lts=[$lts]" >&2
 
-  get /latest-$lts/ | egrep -o '[0-9]+\.[0-9]+\.[0-9]+' | head -n1
+  get latest-$lts/ | egrep -o '[0-9]+\.[0-9]+\.[0-9]+' | head -n1
 }
 
 version_list_named () {


### PR DESCRIPTION
Hi,

I noticed that nave seems to duplicates slashes in urls when downloading (i.e. `https://nodejs.org/dist//v6.9.1/node-v6.9.1-linux-x64.tar.gz`). This doesn't seem to cause any trouble on a mac (and probably other systems) but when I use nave on ubuntu, I get this:

```
robert@robert-VirtualBox:~$ nave use 6.9.1
1 get_ 'https://nodejs.org/dist//v6.9.1/node-v6.9.1-linux-x64.tar.gz' '-#Lf'
curl https://nodejs.org/dist//v6.9.1/node-v6.9.1-linux-x64.tar.gz -#Lf
######################################################################## 100.0%

gzip: stdin: not in gzip format
tar: Child died with signal 13
tar: Error is not recoverable: exiting now
Binary install failed, trying source.
```

I think I've fixed the issue in this PR, but my bash skills aren't great, so I'm not sure if I missed other places or if there is a better way of fixing it :)