### PR TITLE
added arm64 to the osarch to allow for arm64v8 OS's

### DIFF
--- a/nave.sh
+++ b/nave.sh
@@ -47,6 +47,7 @@ osarch () {
     *x86_64*) arch=x64 ;;
     *i[3456]86*) arch=x86 ;;
     *raspberrypi*) arch=arm-pi ;;
+    *aarch64*) arch=arm64 ;;
   esac
   # memoize
   if [ "$os" != "" ] && [ "$arch" != "" ]; then


### PR DESCRIPTION
Hi Isaac,

I'm running this as part of pelias and needed to update the nave.sh to include the right architecture and OS version of nodejs.

I've included an option for the arch to include aarch64 and the mapping to arm64.

Thanks,
Jason.