### PR TITLE
Reset $PATH when exit

### DIFF
--- a/nave.sh
+++ b/nave.sh
@@ -496,7 +496,7 @@ nave_install () {
 
 nave_exit () {
   if [ -n "$NAVEPATH" ]; then
-    export PATH=${PATH:${#NAVEPATH}+1}
+    export PATH=${PATH//:$NAVEPATH/}
   fi
   unset NAVEDEBUG
   unset NAVE_JOBS
@@ -511,7 +511,6 @@ nave_exit () {
   unset NODE_PATH
   unset NAVE_LOGIN
   unset NAVE_DIR
-  unset ZDOTDIR
   unset npm_config_binroot
   unset npm_config_root
   unset npm_config_manroot


### PR DESCRIPTION
Running `nave.sh exit` or `exec nave.sh exit` don't remove `$NAVEPATH` from `$PATH`. This prevent to revert to the system-wide node interpreter when exit the virtual environment.
This misbehavior can be seen from the following asciicast.

[![asciicast](https://asciinema.org/a/tid8G73wbFHEjTkM1yMd2x4Ux.svg)](https://asciinema.org/a/tid8G73wbFHEjTkM1yMd2x4Ux)

Moreover, `$ZDOTDIR` should not be touched by this or other tool. There are zsh users relying on that important variable, and messing with that should be documented and highlighted. Silently unsetting it may generate big issues downstream.